### PR TITLE
[BAM Mediator] NPE thrown when Dump Header & Body of the payload selected and actual message don't have either of this on BAM mediator

### DIFF
--- a/components/mediators/bam/org.wso2.carbon.mediator.bam/src/main/java/org/wso2/carbon/mediator/bam/builders/PayloadDataBuilder.java
+++ b/components/mediators/bam/org.wso2.carbon.mediator.bam/src/main/java/org/wso2/carbon/mediator/bam/builders/PayloadDataBuilder.java
@@ -122,9 +122,18 @@ public class PayloadDataBuilder {
     private Object produceEntityValue(String valueName, MessageContext messageContext){
         try{
             if(valueName.startsWith("$")){ // When entity value is a mediator parameter
-                if("$SOAPHeader".equals(valueName)){
-                    return messageContext.getEnvelope().getHeader().toString();
-                } else if ("$SOAPBody".equals(valueName)){
+                if ("$SOAPHeader".equals(valueName)) {
+                    if (messageContext.getEnvelope().getHeader() != null) {
+                        if (messageContext.getEnvelope().getHeader().getFirstElement() != null) {
+                            return messageContext.getEnvelope().getHeader().toString();
+                        } else {
+                            return "Header is empty";
+                        }
+                    } else {
+                        return "Header is empty";
+                    }
+
+                } else if ("$SOAPBody".equals(valueName)) {
                     return messageContext.getEnvelope().getBody().toString();
                 } else {
                     return "Invalid Entity Parameter !";


### PR DESCRIPTION
When a Pass through proxy created and point to a simple stock quote service as end point and added BAM mediator to both In Sequence and Out Sequence and send a request throwing an exception
1. Create a BAM Server Profile with 2 streams for In and Out sequence with appropriate details and under Stream Configuration Dump Header & Dump Body checked.
2. Create a Pass through Proxy with an endpoint to a Simple Stock Quote service and BAM mediator on both in & out sequence.
3. Invoke a getQoute request and noted the below exception.
[2014-04-07 18:38:53,232] ERROR - MetaDataBuilder Error occurred while extracting the SOAP header or SOAP body. null
java.lang.NullPointerException